### PR TITLE
Pule textos desde la introducción hasta la sección Tipos

### DIFF
--- a/book/README.md
+++ b/book/README.md
@@ -6,11 +6,11 @@ Esta guía va a:
 
 - Enseñarte los fundamentos de programar usando Elm.
 - Mostrarte cómo crear aplicaciones interactivas usando la **Arquitectura Elm**.
-- Enfatizar principios y patrones que pueden generalizarse al programar en cualquier lenguaje.
+- Enfatizar principios y patrones que pueden generalizarse para aplicarlos en cualquier lenguaje de programación.
 
-Al terminar, espero que no sólo seas capaz de crear excelentes aplicaciones web con Elm, pero que también entiendas las ideas y patrones centrales que crean la experiencia de usar Elm.
+Al terminar, espero que no sólo seas capaz de crear excelentes aplicaciones web con Elm, sino que también entiendas las ideas y patrones centrales que forman la experiencia de usar Elm.
 
-Si aún no estás comprometido con usar Elm, te garantizo que si le das una oportunidad y construyes un proyecto usándolo, vas a poder escribir mejor JavaScript que antes. Es muy fácil aplicar las mismas ideas.
+Aunque no tengas completa seguridad de que Elm es para ti, te garantizo que si le das una oportunidad e intentas construir un proyecto usándolo, vas a poder escribir mejor JavaScript que antes. Es muy fácil aplicar las mismas ideas en otros contextos.
 
 ## Sobre la traducción
 
@@ -20,7 +20,7 @@ Antes de empezar, un poquito de contexto. Estás leyendo la traducción no ofici
 
 ¿Quieres escribirnos un **comentario**, mandar una **corrección**, o **aportar** con la traducción o sus aspectos técnicos? [El repositorio en Github](https://github.com/agj/elm-guide-es) es el lugar indicado.
 
-**¿Está al día la traducción?** Puedes [revisar aquí si hay cambios nuevos en el libro original](https://github.com/evancz/guide.elm-lang.org/compare/a6030f9968724629c374b936c552d2b8d2b30f31...master).
+**¿Está al día la traducción?** Puedes [revisar aquí si hay nuevos cambios en el libro original](https://github.com/evancz/guide.elm-lang.org/compare/a6030f9968724629c374b936c552d2b8d2b30f31...master).
 
 ## Un ejemplo sencillo
 
@@ -66,11 +66,11 @@ Al principio, seguro que el código te parecerá extraño, así que pronto vamos
 
 Puedes obtener ciertos beneficios programando en un _estilo_ funcional, pero hay algunas cosas que sólo puedes obtener de un _lenguaje_ funcional como Elm:
 
-- Tener virtualmente ningún error en tiempo de ejecución.
+- Tener cero errores en tiempo de ejecución, en la práctica.
 - Mensajes de error amistosos.
 - Capacidad de refactorizar sin peligro.
-- Versionado semántico (_semver_) para todos los paquetes Elm.
+- Versionado semántico (_semver_) impuesto automáticamente a todos los paquetes Elm.
 
-Ninguna combinación de librerías de JS te dará estas garantías, ya que provienen del diseño del lenguaje mismo. Y gracias a estas garantías, es muy común que programadores de Elm digan que sienten **más confianza** que nunca al programar. Confianza en poder rápidamente añadir nuevas funcionalidades; confianza en poder refactorizar miles de líneas… Y sin la ansiedad de que se te pasó un detalle importante.
+Ninguna combinación de librerías de JS te dará estas garantías, ya que provienen del diseño del lenguaje mismo. Y gracias a estas garantías, es muy común que programadores de Elm digan que sienten más **confianza** que nunca al programar. Confianza en poder rápidamente añadir nuevas funcionalidades; confianza en poder refactorizar miles de líneas… Y sin la ansiedad de que se te pasó un detalle importante.
 
 He puesto mucho énfasis en hacer que Elm sea fácil de aprender y usar, así que todo lo que pido de ti es que le des una oportunidad y formes tu opinión. Espero que sea una grata sorpresa.

--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -1,7 +1,7 @@
 # Summary
 
-- [Introducción](README.md)
-- [Lo esencial del lenguaje](core_language.md)
+- [Introducción a Elm](README.md)
+- [Fundamentos del lenguaje](core_language.md)
 - [Arquitectura Elm](architecture/README.md)
   - [Botones](architecture/buttons.md)
   - [Campos de texto](architecture/text_fields.md)

--- a/book/architecture/README.md
+++ b/book/architecture/README.md
@@ -1,28 +1,28 @@
 # Arquitectura Elm
 
-La Arquitectura Elm es un patrón para arquitecturar programas interactivos, tales como aplicaciones web y videojuegos.
+La Arquitectura Elm es un patrón para construir programas interactivos, tales como aplicaciones web y videojuegos.
 
-Esta arquitectura parece emerger naturalmente en Elm. Más que ser un invento de alguien en particular, los primeros usuarios de Elm redescubrían constantemente los mismos patrones básicos en su código. Era un poco misterioso ver a tanta gente dar con código bien arquitecturado sin haber planificado con antelación.
+Esta arquitectura parece emerger naturalmente en Elm. Más que ser un invento de alguien en particular, los primeros usuarios de Elm redescubrían constantemente los mismos patrones básicos en su código. Fue curioso ver a tanta gente dar con este tipo de código bien arquitecturado sin planificación previa.
 
-La Arquitectura Elm es fácil de usar en Elm, pero es útil en cualquier proyecto de front-end. De hecho, hay proyectos, como Redux, que han sido inspirados por la Arquitectura Elm, así que es posible que ya te hayas topado con derivados de este patrón. El punto es que, aunque en tu trabajo no puedas Elm aún, vas igual a poder sacar provecho de usar Elm e internalizar este patrón.
+Elm, por supuesto, hace muy fácil usar la Arquitectura Elm, pero más allá del lenguaje, es una arquitectura que resulta muy ergonómica para cualquier proyecto de front-end. De hecho, hay proyectos, como Redux, que han sido inspirados por esta arquitectura, así que es posible que ya te hayas topado con derivados de este patrón. El punto es que, aún si en tu trabajo no puedes usar Elm aún, igual puedes sacar provecho de usar Elm e internalizar la arquitectura que te voy a presentar.
 
-## El patrón fundamental
+## El patrón en su esencia
 
 Los programas escritos en Elm siempre se ven más o menos así:
 
 ![Diagrama de la Arquitectura Elm](buttons.svg)
 
-Un programa en Elm produce HTML para mostrar en pantalla, y el computador envía de vuelta mensajes de cosas que ocurren. “Apretaron un botón”, etc.
+Un programa en Elm produce HTML para mostrar en pantalla, y el computador envía de vuelta mensajes (`Msg`) de cosas que ocurren. “Un botón fue apretado”, etc.
 
-¿Y qué ocurre dentro del programa Elm? Se divide en estas tres partes:
+¿Y cómo se organiza internamente el programa? Lo dividimos en estas tres partes:
 
-- **Modelo** — el estado de tu aplicación.
-- **Vista** — una forma de convertir el estado en HTML.
-- **Actualización** — una forma de actualizar tu estado basado en mensajes.
+- **Modelo**: El estado de nuestra aplicación.
+- **Vista**: Una forma de convertir el modelo en HTML.
+- **Actualización**: Cómo se actualiza el modelo en base a mensajes.
 
 Estos tres conceptos son el núcleo de la **Arquitectura Elm**.
 
-Los siguientes ejemplos te demostrarán cómo usar este patrón para interpretar entrada del usuario, como botones y campos de texto. Vamos a hacer concreto todo lo que te acabo de decir.
+Los siguientes ejemplos te demostrarán cómo usar este patrón para interpretar acciones del usuario, como el presionar botones e ingreso en campos de texto. Vamos a hacer concreto todo lo que te acabo de decir.
 
 ## Hagámoslo juntos
 
@@ -30,7 +30,7 @@ Todos los ejemplos están disponibles en el editor online:
 
 [![editor online](try.png)](https://elm-lang.org/try)
 
-Este editor muestra tips en la esquina superior izquierda:
+Este editor muestra tips en la esquina superior izquierda (dice “Hint”):
 
 <video id="hints-video" width="360" height="180" autoplay loop style="margin: 0.55em 0 1em 2em;" onclick="var v = document.getElementById('hints-video'); v.paused ? (v.play(), v.style.opacity = 1) : (v.pause(), v.style.opacity = 0.5)">
   <source src="hints.mp4" type="video/mp4">

--- a/book/architecture/buttons.md
+++ b/book/architecture/buttons.md
@@ -1,8 +1,8 @@
 # Botones
 
-Nuestro primer ejemplo es un contador que puede incrementarse o decrementarse.
+Nuestro primer ejemplo es un contador, con un número que se puede aumentar o disminuir.
 
-Abajo está el programa completo. Si apretas el botón “Editar” puedes jugar con el código interactivamente en el editor online. Prueba cambiar el texto de uno de los botones. **¡Apreta el botón azul!**
+Aquí abajo tienes el programa completo. Si apretas el botón azul “Editar” puedes jugar con el código interactivamente en el editor online. Prueba cambiar el texto de uno de los botones. Dale y **apreta el botón azul.**
 
 <div class="edit-link"><a href="https://elm-lang.org/examples/buttons">Editar</a></div>
 
@@ -65,19 +65,24 @@ view model =
         ]
 ```
 
-Ahora que ya has jugado un poco con el código, seguramente tienes algunas preguntas. ¿Qué hace el valor `main`? ¿Cómo calzan todas estas partes? Discutámoslo parte por parte.
+Ahora que ya has jugado un poco con el código, seguramente tienes algunas preguntas, como: ¿Qué hace el valor `main`? ¿Cómo calzan todas estas piezas que veo aquí? Discutámoslo parte por parte.
 
-> **Nota:** El código usa [anotaciones de tipo](/types/reading_types.html), [tipos alias](/types/type_aliases.html), y [tipos personalizados](/types/custom_types.html). El punto de esta sección es que agarres una idea de la Arquitectura Elm, por lo que no vamos a entrar en esos temas hasta después. Te sugiero que no te adelantes, aunque te compliquen un poco estos aspectos.
+> **Nota:** El código usa [anotaciones de tipo](/types/reading_types.html), [alias de tipo](/types/type_aliases.html), y [tipos personalizados](/types/custom_types.html). El punto de esta sección es que te hagas una idea de la Arquitectura Elm, por lo que no vamos a entrar en esos temas hasta después. Pero si estos conceptos te confunden, siéntete libre de adelantarte un poco y quitarte las dudas.
 
 ## Main
 
-El valor `main` tiene un significado especial en Elm. Describe lo que se muestra en pantalla. En este caso, vamos a inicializar nuestra aplicación con el valor `init`, la función `view` va a mostrar todo en pantalla, y la entrada de usuario va a ser ingresada a la función `update`. `main` es como la descripción global de nuestro programa.
+El valor `main` (“principal”) tiene un significado especial en Elm: describe lo que se mostrará en pantalla. En este caso, estamos diciendo que el valor `init` inicializará nuestra aplicación, la función `view` va a mostrar todo en pantalla, y las acciones del usuario irán a parar a la función `update`. `main` es como la descripción global de nuestro programa.
 
-## Modelo
+```elm
+main =
+    Browser.sandbox { init = init, update = update, view = view }
+```
 
-El modelado de datos es extremadamente importante en Elm. El punto del **modelo** es capturar todos los detalles de tu aplicación en forma de datos.
+## Modelo (`Model`)
 
-Para hacer un contador, necesitamos tener un número que aumentará o bajará. Eso significa que en esta ocasión el modelo es muy pequeño:
+El modelado de datos es extremadamente importante en Elm. El punto del modelo es capturar todos los detalles de tu aplicación en forma de datos.
+
+Para hacer un contador, lo que necesitamos es un número que subirá o bajará. Eso significa que en esta ocasión el modelo es muy simple:
 
 ```elm
 type alias Model =
@@ -92,9 +97,9 @@ init =
     0
 ```
 
-El valor inicial es cero, y éste subirá o bajará según la gente aprete los botones.
+El valor inicial es cero, y éste subirá o bajará según los botones que apretemos.
 
-## Vista
+## Vista (`view`)
 
 Tenemos un modelo, pero ¿cómo lo mostramos en pantalla? Ese es el rol de la función `view`:
 
@@ -108,11 +113,11 @@ view model =
         ]
 ```
 
-Esta función recibe el `Model` como un argumento, y retorna HTML. Estamos diciendo que queremos un botón de decremento, la cuenta actual, y un botón de incremento.
+Esta función recibe `Model` como un argumento, y retorna HTML. Estamos diciendo que queremos un botón para reducir, la cuenta actual, y un botón para aumentar.
 
-Nótese que tenemos una suscripción al evento `onClick` para cada botón. Estamos diciendo: **cuando alguien haga clic, genera un mensaje**. Dado esto, el botón “+” está generando un mensaje `Increment`. ¿Qué es eso y a dónde va a parar? Bueno, terminará en la función `update`.
+Nótese que tenemos una suscripción al evento `onClick` en cada botón. Estamos diciendo: **cuando alguien haga clic, genera un mensaje**. En este caso, el botón “+” está generando un mensaje `Increment`. ¿Qué es eso, y a dónde va a parar? Veamos la función `update`.
 
-## Actualización
+## Actualización (`update`)
 
 La función `update` describe cómo nuestro `Model` cambiará en el tiempo.
 
@@ -124,7 +129,7 @@ type Msg
     | Decrement
 ```
 
-Después, la función `update` simplemente describe qué se debe hacer cuando se recibe uno de estos mensajes.
+Después, la función `update` simplemente describe qué se debe hacer cuando se recibe alguno de estos mensajes.
 
 ```elm
 update : Msg -> Model -> Model
@@ -137,31 +142,31 @@ update msg model =
             model - 1
 ```
 
-Si recibe un mensaje `Increment`, incrementamos el modelo. Si recibe un mensaje `Decrement`, decrementamos el modelo.
+Si recibe un mensaje `Increment`, sumamos 1 al modelo. Si recibe un mensaje `Decrement`, restamos 1 al modelo.
 
-Cada vez que recibimos un mensaje, se le suplirá a la función `update` para generar un nuevo modelo. Después llamamos a `view` para saber cómo mostrar este modelo en pantalla. Y así sucesivamente. Las interacciones del usuario generan un mensaje, actualizamos el modelo con `update`, lo mostramos en pantalla con `view`. Etc.
+Cada vez que se produzca un mensaje, éste pasará por la función `update` para generar un nuevo modelo. Después, la función `view` es llamada para saber cómo mostrar este modelo en pantalla. Y esto se seguirá repitiendo indefinidamente. Las acciones del usuario generan un mensaje, actualizamos el modelo con `update`, lo mostramos en pantalla con `view`. Etc.
 
 ## Resumen
 
-Ahora que hemos visto todas las partes de un programa Elm, tal vez sea más fácil entender cómo se relacionan con el diagrama que vimos antes:
+Ahora que hemos visto todas las partes de un programa en Elm, tal vez sea más fácil entender cómo se relacionan con el diagrama que vimos antes:
 
 ![Diagrama de la Arquitectura Elm](buttons.svg)
 
-Elm empieza visualizando el valor inicial en pantalla. Después, entras en este loop:
+Elm empieza visualizando el valor inicial en pantalla. Después se repiten los siguientes pasos:
 
-1. Esperar interacción del usuario.
-2. Mandar un mensaje a `update`.
-3. Producir un nuevo `Model`.
-4. Llamar a `view` para obtener un nuevo HTML.
-5. Mostrar el nuevo HTML en pantalla.
-6. Y se repite.
+1. Se espera una acción del usuario.
+2. Se manda un mensaje a `update`.
+3. Se produce un nuevo `Model`.
+4. Se llama a `view` para obtener un nuevo HTML.
+5. Se muestra el nuevo HTML en pantalla.
+6. Y repetimos.
 
-Esta es la esencia de la Arquitectura Elm. Todos los ejemplos que veamos a partir de aquí serán sólo leves variaciones de este patrón fundamental.
+Esta es la esencia de la Arquitectura Elm. Todos los ejemplos que veamos de aquí en adelante serán sólo leves variaciones de este patrón fundamental.
 
 > **Ejercicio:** Añade un botón que reinicie el contador en cero:
 >
 > 1. Añade una variante `Reset` en el tipo `Msg`.
-> 2. Añade una rama `Reset` en la función `update`.
+> 2. Añade una rama de ejecución `Reset` en la función `update`.
 > 3. Añade un botón en la función `view`.
 >
 > Puedes editar el ejemplo en el editor online [aquí](https://elm-lang.org/examples/buttons).

--- a/book/architecture/forms.md
+++ b/book/architecture/forms.md
@@ -1,8 +1,8 @@
 # Formularios
 
-Vamos a crear un pequeño formulario. Tiene un campo para tu nombre, otro para tu clave, y otro para verificar la clave. También vamos a hacer un poco de validación para asegurarnos de que ambas claves son iguales.
+Vamos a crear un pequeño formulario. Tendrá un campo para un nombre, otro para la clave, y otro para verificar la clave. También vamos a hacer un poco de validación para asegurarnos de que ambas claves son iguales.
 
-Abajo tienes el programa completo. Puedes abrirlo en el editor online. Trata de escribir algo mal para ver mensajes de error. Por ejemplo, cambia el nombre de un campo, como `password`, o de una función, como `placeholder`. **¡Apreta el botón azul!**
+Abajo está el programa completo. Puedes abrirlo en el editor online. Prueba escribir algo mal en el código para ver mensajes de error. Por ejemplo, cambia el nombre de un campo, como `password`, o de una función, como `placeholder`. **¡Apreta el botón azul!**
 
 <div class="edit-link"><a href="https://elm-lang.org/examples/forms">Editar</a></div>
 
@@ -152,7 +152,7 @@ view model =
 
 En ejemplos anteriores usábamos `input` y `div` directamente. ¿Por qué aquí no?
 
-Lo bueno del HTML en Elm es que `input` y `div` son sólo funciones comunes y corrientes. Reciben (1) una lista de atributos, y (2) una lista de nodos hijo. **Ya que son sólo funciones, tenemos el poder completo de Elm para construir nuestras vistas.** Podemos refactorizar código repetitivo y ponerlo en funciones de ayuda de nuestra propia creación. Y eso es justamente lo que estamos haciendo aquí.
+Lo bueno del HTML en Elm es que `input` y `div` no son más que funciones comunes y corrientes. Reciben (1) una lista de atributos, y (2) una lista de nodos hijo. **Ya que son sólo funciones, tenemos el poder completo de Elm para construir nuestras vistas.** Podemos refactorizar código repetitivo y ponerlo en funciones de ayuda de nuestra propia creación. Y eso es justamente lo que estamos haciendo aquí.
 
 La función `view` hace tres llamadas a `viewInput`:
 
@@ -164,7 +164,7 @@ viewInput t p v toMsg =
 
 Esto significa que si escribimos `viewInput "text" "Name" "Bill" Name` en Elm, se convertiría en un valor HTML como `<input type="text" placeholder="Name" value="Bill">` cuando se despliegue en pantalla.
 
-El cuarto hijo es más interesante. Es una llamada a `viewValidation`:
+El cuarto elemento hijo es más interesante. Es una llamada a `viewValidation`:
 
 ```elm
 viewValidation : Model -> Html msg
@@ -176,17 +176,17 @@ viewValidation model =
         div [ style "color" "red" ] [ text "Passwords do not match!" ]
 ```
 
-Esta función primero compara las dos claves. Si son iguales, retorna un texto en verde y un mensaje de afirmación. Si no son iguales, retorna un texto en rojo y un mensaje de ayuda.
+Esta función primero compara las dos claves. Si son iguales, retorna un texto en verde con un mensaje de confirmación. Si no son iguales, retorna un texto en rojo con un mensaje de ayuda.
 
-Estas funciones de ayuda ya empiezan a mostrar el beneficio de que nuestra librería de HTML sea sólo código Elm. Podríamos haber puesto todo este código dentro de `view`, pero crear funciones de ayuda es completamente normal en Elm, incluyendo en el código de la vista. “Parece que está un poco difícil de entender. Probemos extrayéndolo a una función de ayuda”.
+Estas funciones de ayuda ya empiezan a mostrar el beneficio de que nuestra librería de HTML sea sólo código Elm. Podríamos haber puesto todo este código dentro de `view`, pero crear funciones de ayuda es completamente normal en Elm, incluso para el código de la vista. Es habitual pensar: “Parece que está un poco difícil de entender. Probemos extrayéndolo a una función de ayuda”.
 
-> **Ejercicios:** [Revisa este ejemplo](https://elm-lang.org/examples/forms) en el editor online. Intenta añadir las siguientes funcionalidades a la función `viewValidation`:
+> **Ejercicios:** [Revisa el ejemplo en el editor online.](https://elm-lang.org/examples/forms) Intenta añadir las siguientes funcionalidades a la función `viewValidation`:
 >
-> - Confirma que la clave es más larga que 8 caracteres.
+> - Confirma que la clave tiene más de 8 caracteres.
 > - Asegura que la clave tiene letras mayúsculas, minúsculas y dígitos numéricos.
 >
 > Usa las funciones del módulo [`String`](https://package.elm-lang.org/packages/elm/core/latest/String) para completar estos ejercicios.
 >
-> **Advertencia:** Necesitamos aprender mucho más antes de poder enviar una solicitud HTTP. Sigue leyendo en orden hasta llegar a la sección sobre HTTP antes de intentarlo por tu cuenta. Te va a resultar mucho más fácil siguiendo esta guía.
+> **Advertencia:** Necesitamos aprender mucho más antes de poder enviar una solicitud HTTP. Sigue leyendo en orden hasta llegar a la sección sobre HTTP antes de intentarlo por tu cuenta. Te va a resultar mucho más fácil si sigues esta guía.
 >
-> **Nota:** Parece que los intentos de hacer librerías genéricas de validación no han dado muchos frutos. Creo que el problema es que los chequeos son más comúnmente resueltos con funciones normales. Éstas reciben argumentos y retornan un `Bool` o un `Maybe`. O sea, ¿para qué usar una librería para revisar que dos textos son iguales? De lo que hemos aprendido, el código más simple surge al escribir la lógica para tu caso particular, sin extras añadidos. Así que siempre intenta hacer esto antes de decidir que necesitas una solución más compleja.
+> **Nota:** Parece que los intentos de hacer librerías genéricas de validación no han dado muchos frutos. Creo que el problema es que los chequeos son más fácilmente resueltos con funciones comunes y corrientes, que reciben argumentos y retornan un `Bool` o un `Maybe`. Es decir, no necesitamos una librería para revisar, por ejemplo, que dos textos son iguales. De lo que hemos aprendido desarrollando y usando Elm, el código más simple es resultado de escribir la lógica necesaria para nuestro caso particular, sin añadir nada más. Así que te sugiero que siempre intentes hacer esto antes de probar una solución más compleja.

--- a/book/architecture/text_fields.md
+++ b/book/architecture/text_fields.md
@@ -1,8 +1,8 @@
 # Campos de texto
 
-Vamos a crear una simple aplicación que escribe al revés lo que pongas en un campo de texto.
+Vamos a crear una simple aplicación que escribe al revés lo que ingreses en un campo de texto.
 
-Ahora abre este programa en el editor online. Revisa el tip que aparece cuando pones el cursor sobre la palabra `type`. **¡Apreta el botón azul!**
+Abre este programa en el editor online, y fíjate en el tip que aparece cuando pones el cursor sobre la palabra `type`. **¡Apreta el botón azul!**
 
 <div class="edit-link"><a href="https://elm-lang.org/examples/text-fields">Editar</a></div>
 
@@ -62,11 +62,11 @@ view model =
         ]
 ```
 
-Este código es una ligera variación del ejemplo anterior. Primero configuras un modelo. Defines unos mensajes. Dices cómo actualizar con `update`. Defines la vista en `view`. La diferencia es sólo el cómo rellenamos este esqueleto. Vamos parte por parte.
+Este código es una ligera variación del ejemplo anterior. Configuramos un modelo, definimos unos mensajes, decimos cómo actualizar el modelo con `update`, y definimos la vista en `view`. La diferencia está sólo en cómo completamos este esqueleto. Veamos parte por parte.
 
 ## Modelo
 
-Siempre empiezo tratando de imaginar cómo tiene que ser mi `Model`. Sabemos que tenemos que llevar cuenta de lo que el usuario haya escrito en el campo de texto. Necesitamos esa información para saber cómo mostrar el texto al revés. Así que probamos con esto:
+Yo siempre comienzo tratando de imaginar cómo tiene que ser mi `Model`. De partida sabemos que necesitamos llevar cuenta de lo que el usuario haya escrito en el campo de texto, porque necesitamos esa información para saber cómo mostrar el texto al revés. Así que probamos con esto:
 
 ```elm
 type alias Model =
@@ -74,13 +74,13 @@ type alias Model =
     }
 ```
 
-Esta vez decidí representar el modelo como un registro. El registro guarda la información ingresada por el usuario en el campo `content`.
+Esta vez decidí representar el modelo como un registro. El registro alberga el texto ingresado por el usuario en el campo `content`.
 
-> **Nota:** Tal vez te surja la duda de por qué usar un registro cuando sólo tiene un campo. ¿No podríamos usar `String` directamente? Claro que sí. Pero si empezamos con un registro, se hace más fácil después añadir más campos a medida que nuestra aplicación se hace más complicada. Cuando llegue el momento en que necesitemos _dos_ campos de texto, vamos a tener que hacer mucho menos trabajo.
+> **Nota:** Tal vez te surja la duda de por qué usar un registro con un sólo campo. ¿No podríamos usar `String` directamente? Claro que sí. Pero si empezamos con un registro, se hace más fácil después añadir más campos a medida que nuestra aplicación se haga más compleja. Cuando llegue el momento en que necesitemos _dos_ campos de texto, tendremos que hacer mucho menos trabajo.
 
 ## Vista
 
-Ya tenemos un modelo, así que normalmente lo siguiente que hago es crear la función `view`:
+Ya teniendo el modelo, lo que normalmente hago después es crear la función `view`:
 
 ```elm
 view : Model -> Html Msg
@@ -93,16 +93,16 @@ view model =
 
 Creamos un `<div>` con dos hijos. El hijo que más nos interesa es el nodo `<input>`, que tiene tres atributos:
 
-- `placeholder` es el texto que se muestra cuando no hay contenido
-- `value` es el contenido actual de este `<input>`
-- `onInput` envía mensajes cuando el usuario escribe algo en este nodo `<input>`
+- `placeholder` es el texto que se muestra cuando no hay contenido.
+- `value` es el contenido actual de este `<input>`.
+- `onInput` produce mensajes cuando el usuario escribe algo en este nodo `<input>`.
 
-Si escribes “bard” vas a producir cuatro mensajes:
+Si escribes “sala” vas a producir cuatro mensajes:
 
-1. `Change "b"`
-2. `Change "ba"`
-3. `Change "bar"`
-4. `Change "bard"`
+1. `Change "s"`
+2. `Change "sa"`
+3. `Change "sal"`
+4. `Change "sala"`
 
 Estos serán ingresados a nuestra función `update`.
 
@@ -122,15 +122,15 @@ update msg model =
             { model | content = newContent }
 ```
 
-Cuando recibimos un mensaje de que hubo un cambio en nuestro `<input>`, actualizamos el campo `content` del modelo. Así que si escribes “bard”, los mensajes resultantes producirían estos modelos:
+Cuando recibimos un mensaje indicando que hubo un cambio en nuestro `<input>`, actualizamos el campo `content` del modelo. Así que si escribimos “sala”, los mensajes resultantes producirían estos modelos:
 
-1. `{ content = "b" }`
-2. `{ content = "ba" }`
-3. `{ content = "bar" }`
-4. `{ content = "bard" }`
+1. `{ content = "s" }`
+2. `{ content = "sa" }`
+3. `{ content = "sal" }`
+4. `{ content = "sala" }`
 
-Necesitamos llevar cuenta de esta información en el modelo en forma explícita.Si no, no tendríamos cómo mostrar el texto al revés en nuestra función `view`.
+Necesitamos llevar cuenta de esta información en el modelo en forma explícita. Si no, no tendríamos cómo mostrar el texto al revés en nuestra función `view`.
 
-> **Ejercicio:** Abre el ejemplo en el editor online [aquí](https://elm-lang.org/examples/text-fields), y muestra el largo del campo `content` en tu función `view`. Usa la función [`String.length`](https://package.elm-lang.org/packages/elm/core/latest/String#length).
+> **Ejercicio:** Abre el ejemplo en el editor online [aquí](https://elm-lang.org/examples/text-fields), y pon la cantidad de caracteres que tiene el campo `content` en tu función `view`. Usa la función [`String.length`](https://package.elm-lang.org/packages/elm/core/latest/String#length) para lograrlo.
 >
 > **Nota:** Si quieres más información sobre exactamente cómo funcionan los valores `Change` en este programa, revisa las secciones posteriores sobre [tipos personalizados](/types/custom_types.html) y [búsqueda de patrones](/types/pattern_matching.html).

--- a/book/core_language.md
+++ b/book/core_language.md
@@ -1,8 +1,8 @@
-# Lo esencial del lenguaje
+# Fundamentos del lenguaje
 
 Intentemos primero construir una intuición sobre cómo funciona Elm.
 
-El objetivo es familiarizarnos con **valores** y **funciones**, y tomar confianza para cuando nos enfrentemos a ejemplos más largos de código.
+El objetivo es familiarizarnos con los conceptos de **valores** y **funciones**, y adquirir confianza para cuando nos enfrentemos a ejemplos más largos de código.
 
 ## Valores
 
@@ -22,11 +22,11 @@ Veamos primero los números.
 {% endrepl %}
 <!-- prettier-ignore-end -->
 
-Todos los ejemplos en esta página son interactivos. Si apretas sobre esta caja negra ⬆️ vas a ver que el cursor de texto va a empezar a pestañear. Escribe `2 + 2` y apreta ENTER. Deberías ver que aparece `4` como resultado. Recuerda que puedes interactuar de la misma forma con todos los demás ejemplos en este documento.
+Todos los ejemplos en esta página son interactivos. Si apretas sobre esta caja negra ⬆️ verás que el cursor de texto empezará a pestañear. Escribe `2 + 2` y apreta ENTER. Deberías ver que aparece `4` como resultado. Recuerda que puedes interactuar de la misma forma con todos los demás ejemplos en este documento.
 
 Prueba escribir algo como `30 * 60 * 1000` o `2 ^ 4`. Verás que funciona igual que una calculadora.
 
-Está bien hacer aritmética, pero es algo sorprendentemente poco común en la mayoría de programas que uno escribe. Es mucho más frecuente manipular textos, lo que en informática se llama técnicamente **string**. Algo así:
+Está muy bien poder hacer aritmética, pero es algo sorprendentemente poco común en la mayoría de programas que uno escribe. Es mucho más frecuente manipular textos, lo que en informática llamamos técnicamente **strings**. Algo así:
 
 <!-- prettier-ignore-start -->
 {% repl %}
@@ -45,9 +45,9 @@ Está bien hacer aritmética, pero es algo sorprendentemente poco común en la m
 {% endrepl %}
 <!-- prettier-ignore-end -->
 
-Prueba unir varios strings con el operador `(++)` ⬆️
+Prueba juntar varios strings con el operador `(++)` ⬆️
 
-Estos valores primitivos se vuelven más interesantes a medida que escribamos funciones para transformarlos.
+Estos valores primitivos que hemos visto se vuelven más interesantes a medida que escribamos funciones para transformarlos.
 
 > **Nota:** Puedes leer más sobre distintos operadores, como [`(+)`](op-plus), [`(/)`](op-div) y [`(++)`](op-concat) en la documentación del módulo [`Basics`](core-basics). Lamentablemente, esta documentación está en inglés, pero está escrita en un lenguaje muy poco técnico, y aunque sea con traducción automática, creo que vale la pena darle una leída una vez que te parezca apropiado.
 
@@ -58,9 +58,9 @@ Estos valores primitivos se vuelven más interesantes a medida que escribamos fu
 
 ## Funciones
 
-Una **función** es una forma de transformar valores. Éstas toman algunos valores, y producen un nuevo valor.
+Una **función** es una forma de transformar valores. Reciben ciertos valores, y en base a ellos producen un nuevo valor.
 
-Por ejemplo, esta es una función `greet` que recibe un nombre y dice “hola”:
+Por ejemplo, esta es una función `greet` que recibe un nombre y devuelve un saludo:
 
 <!-- prettier-ignore-start -->
 {% repl %}
@@ -87,9 +87,9 @@ Por ejemplo, esta es una función `greet` que recibe un nombre y dice “hola”
 
 Trata saludar a alguna otra persona, como a `"Stokely"` o a `"Kwame"` ⬆️
 
-Los valores que le pasas a la función se suelen llamar **argumentos**, así que podríamos decir que `greet` es una función que recibe un argumento.
+Los valores que le pasas a la función se suelen llamar **argumentos**, así que podríamos decir que `greet` es una función que recibe un solo argumento.
 
-Bien, ahora que terminamos las formalidades, ¿qué te parece si probamos una función `madlib` que recibe _dos_ argumentos?
+Y ahora que terminamos de saludarnos, ¿qué te parece si probamos una función `madlib` que recibe _dos_ argumentos?
 
 <!-- prettier-ignore-start -->
 {% repl %}
@@ -114,11 +114,11 @@ Bien, ahora que terminamos las formalidades, ¿qué te parece si probamos una fu
 {% endrepl %}
 <!-- prettier-ignore-end -->
 
-Intenta darle dos argumentos a la función `madlib` ⬆️
+Intenta pasarle dos argumentos a la función `madlib` ⬆️
 
 Observa que usamos paréntesis para agrupar `"butter" ++ "fly"` en el segundo ejemplo. Cada argumento necesita ser un valor primitivo, como `"gato"`, y si no, necesitas usar paréntesis.
 
-> **Nota:** Si estás habituado a lenguajes como JavaScript, te puede sorprender que las funciones se ven distintas:
+> **Nota:** Si estás habituado a lenguajes como JavaScript, te habrás dado cuenta de que las funciones se ven distintas:
 >
 >     madlib "cat" "ergonomic"                  -- Elm
 >     madlib("cat", "ergonomic")                // JavaScript
@@ -126,13 +126,13 @@ Observa que usamos paréntesis para agrupar `"butter" ++ "fly"` en el segundo ej
 >     madlib ("butter" ++ "fly") "metallic"      -- Elm
 >     madlib("butter" + "fly", "metallic")       // JavaScript
 >
-> Te puede parecer raro al principio, pero para este estilo necesitamos usar menos paréntesis y comas. Cuando te acostumbres vas a ver que el lenguaje se siente más simple y limpio.
+> Te puede parecer raro al principio, pero este estilo necesita usar menos paréntesis y comas. Una vez que te acostumbres verás que el lenguaje se siente más simple y limpio.
 
 ## Expresiones `if`
 
-Cuando necesitas comportamiento condicional en Elm, puedes usar una expresión `if`.
+Cuando necesitamos comportamiento condicional en Elm, podemos usar una expresión `if`.
 
-Creemos una nueva función `greet` que es adecuadamente respetuosa con el expresidente Abraham Lincoln.
+Creemos una nueva función `greet` que es apropiadamente respetuosa con el presidente Abraham Lincoln.
 
 <!-- prettier-ignore-start -->
 {% repl %}
@@ -323,9 +323,9 @@ También es útil **actualizar** valores en un registro:
 {% endrepl %}
 <!-- prettier-ignore-end -->
 
-Si intentamos leer en voz alta las expresiones de arriba, diríamos algo como “Quiero una versión de John cuyo apellido es Adams”, o “cuya edad es 22”.
+Si intentáramos leer en voz alta las expresiones de arriba, diríamos algo como “Quiero una versión de John cuyo apellido es Adams”, o “cuya edad es 22”.
 
-Nótese que al actualizar los campos de `john`, estamos creando un registro completamente nuevo. El registro original no ha sido sobreescrito. Elm permite hacer esto en forma eficiente, compartiendo todo lo que pueda entre ambos. Si actualizas uno en diez campos, el nuevo registro va a compartir los otros nueve.
+Nótese que al actualizar los campos de `john`, estamos creando un registro completamente nuevo. El registro original no ha sido sobreescrito. Elm permite hacer esto en forma eficiente, compartiendo todo lo que pueda entre ambos. Si actualizas un campo entre diez, el nuevo registro va a compartir los otros nueve.
 
 Dicho esto, una función que actualiza la edad quedaría así:
 

--- a/book/types/README.md
+++ b/book/types/README.md
@@ -1,6 +1,6 @@
 # Tipos
 
-Uno de los más grandes beneficios de usar Elm es que **tus usuarios virtualmente no verán errores en tiempo de ejecución**. Esto ocurre porque el compilador de Elm puede analizar tu código muy rápidamente y saber cómo fluyen los valores a través de tu programa. Si existen formas de usar valors de manera inválida, el compilador te avisa con un mensaje de error amistoso. Esto se llama _inferencia de tipos_. El compilador resuelve los _tipos_ de los valores que fluyen a través de todas tus funciones.
+Uno de los más grandes beneficios de usar Elm es que **en la práctica, tus usuarios nunca se toparán con excepciones de ejecución**. Esto ocurre porque el compilador de Elm puede rápidamente analizar el código y entender cómo fluye cada valor a través del programa. Si encuentra usos inválidos de estos valores, el compilador nos avisa con un mensaje de error fácil de entender. Esto se llama _inferencia de tipos_. El compilador resuelve los _tipos_ de los valores que fluyen a través de todas las funciones del programa.
 
 ## Un ejemplo de inferencia de tipos
 
@@ -15,9 +15,9 @@ fullName =
     toFullName { fistName = "Hermann", lastName = "Hesse" }
 ```
 
-Tal como en JavaScript o Python, sólo necesitamos escribir el código, sin anotaciones. Pero, ¿notaste el error?
+Tal como en JavaScript o Python, sólo necesitamos escribir el código, sin anotar tipos. Pero **¿notaste el error?**
 
-En JavaScript, código equivalente a este respondería con `"undefined Hesse"`. ¡Ni siquiera sería un error! Con un poco de suerte, uno de tus usuarios te avisaría cuando lo vea durante el uso. Por otro lado, el compilador de Elm revisa tu código y te da esta retroalimentación:
+Si escribiéramos lo mismo en JavaScript, el resultado sería `"undefined Hesse"`. ¡Ni siquiera sería un error! Con un poco de suerte, uno de tus usuarios te avisaría cuando lo vea durante el uso. Por otro lado, el compilador de Elm revisa tu código y te da esta retroalimentación:
 
 ```
 -- TYPE MISMATCH ---------------------------------------------------------------
@@ -40,10 +40,10 @@ Hint: Can more type annotations be added? Type annotations always help me give
 more specific messages, and I think they could help a lot in this case!
 ```
 
-“El argumento a la función `toFullName` no calza. La función `toFullName` espera que el argumento sea: (…) Pero es: (…)”
+Traducido, dice: “El primer argumento a `toFullName` no es lo que esperaba: (…) Este argumento es un registro de tipo: (…) Pero `toFullName` necesita que el primer argumento sea: (…)”
 
-Se dio cuenta de que `toFullName` está recibiendo el _tipo_ de argumento incorrecto. La ayuda en _Hint_ también muestra que escribiste “fist” en vez de “first”.
+Se dio cuenta de que `toFullName` está recibiendo el _tipo_ de argumento incorrecto. Los tips abajo en _Hint_ también muestran que escribiste “fist” en vez de “first”.
 
-Es muy útil tener esta ayuda para identificar errores simples como este, pero es invaluable cuando tienes cientos de archivos de código y varios contribuyentes haciendo cambios. No importa cuán grande y compleja se vuelva la aplicación, el compilador de Elm revisa que _todo_ calce correctamente sólo en base a tu código.
+Es muy útil tener esta ayuda para identificar errores simples como este, pero es invaluable cuando tienes cientos de archivos de código y varios contribuyentes haciendo cambios. No importa cuán grande y compleja se vuelva la aplicación, el compilador de Elm revisa que _todo_ calce correctamente, sólo en base al análisis de tu código.
 
-Mientras mejor entiendas los tipos, más sentirás que el compilador es como un asistente amigo. ¡Aprendamos más, entonces!
+Mientras mejor entiendas los tipos, más sentirás que el compilador es como un asistente amigo. Dicho esto, continuemos para aprender más sobre los tipos.

--- a/book/types/README.md
+++ b/book/types/README.md
@@ -22,21 +22,22 @@ En JavaScript, código equivalente a este respondería con `"undefined Hesse"`. 
 ```
 -- TYPE MISMATCH ---------------------------------------------------------------
 
-The argument to function `toFullName` is causing a mismatch.
+The 1st argument to `toFullName` is not what I expect:
 
-6│   toFullName { fistName = "Hermann", lastName = "Hesse" }
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Function `toFullName` is expecting the argument to be:
+6|       toFullName { fistName = "Hermann", lastName = "Hesse" }
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+This argument is a record of type:
 
-    { …, firstName : … }
+    { fistName : String, lastName : String }
 
-But it is:
+But `toFullName` needs the 1st argument to be:
 
-    { …, fistName : … }
+    { a | firstName : String, lastName : String }
 
-Hint: I compared the record fields and found some potential typos.
+Hint: Seems like a record field typo. Maybe firstName should be fistName?
 
-    firstName <-> fistName
+Hint: Can more type annotations be added? Type annotations always help me give
+more specific messages, and I think they could help a lot in this case!
 ```
 
 “El argumento a la función `toFullName` no calza. La función `toFullName` espera que el argumento sea: (…) Pero es: (…)”

--- a/book/types/custom_types.md
+++ b/book/types/custom_types.md
@@ -1,4 +1,4 @@
-> **Nota:** Los tipos personalizados solían llamarse “tipos de unión” en Elm. En otras partes puede que los hayas oído llamar como [“tipos de datos algebraicos”](https://es.wikipedia.org/wiki/Tipo_de_dato_algebraico), también.
+> **Nota:** Los tipos personalizados solían llamarse “tipos de unión” en Elm. En otras partes puede que los hayas oído llamar como [“unión etiquetada”](https://academia-lab.com/enciclopedia/union-etiquetada/) o [“tipos de datos algebraicos”](https://es.wikipedia.org/wiki/Tipo_de_dato_algebraico), también.
 
 # Tipos personalizados
 
@@ -6,7 +6,7 @@ Hasta ahora hemos visto muchos tipos, como `Bool`, `Int` y `String`. Pero ¿cóm
 
 Imaginemos que queremos crear un chat. Cada usuario necesita un nombre, pero tal vez algunos usuarios no tienen cuenta permanente, solamente escriben un nombre cada vez que entran.
 
-Podemos describir esta situación definiendo un tipo `UserStatus` que lista todas las posibles variaciones:
+Podemos describir esta situación definiendo un tipo `UserStatus` que lista todas las posibilidades:
 
 ```elm
 type UserStatus
@@ -36,7 +36,7 @@ kate95 =
     { status = Visitor, name = "kate95" }
 ```
 
-Ahora podemos llevar cuenta de si un usuario es `Regular`, o sea que tiene cuenta, o es `Visitor`, es decir visitante temporal. No está tan mal, pero podemos simplificarlo aún más.
+Ahora podemos llevar cuenta de si un usuario es `Regular`, o sea que tiene cuenta, o es `Visitor`, un visitante temporal. No está tan mal, pero podemos simplificarlo aún más.
 
 En vez de crear un tipo personalizado y un alias de tipo, podemos representar todo esto con un sólo tipo personalizado. Las variantes `Regular` y `Visitor` pueden llevar información asociada. En nuestro caso, la información es un valor `String`:
 
@@ -56,7 +56,7 @@ kate95 =
 
 La información se asocia directamente a la variante, y ya no hay necesidad de definir un registro.
 
-Otro beneficio de esta manera de hacerlo es que cada variante puede tener distinta información asociada. Por ejemplo, los usuarios `Regular` podrían informar su edad al registrarse. No hay una buena manera de capturar eso con registros, pero cuando defines tu propio tipo personalizado, ya no es problema. Añadamos un poco de información a la variante `Regular` en un ejemplo interactivo:
+Otro beneficio de esta manera de hacerlo es que cada variante puede tener distinta información asociada. Por ejemplo, los usuarios `Regular` podrían informar su edad al registrarse. No hay una buena manera de capturar eso usando registros, pero cuando definimos un tipo personalizado, ya no es problema. Añadamos un poco de información a la variante `Regular` en un ejemplo interactivo:
 
 <!-- prettier-ignore-start -->
 {% replWithTypes %}
@@ -89,9 +89,9 @@ Otro beneficio de esta manera de hacerlo es que cada variante puede tener distin
 {% endreplWithTypes %}
 <!-- prettier-ignore-end -->
 
-Define un usuario `Regular` con nombre y edad ⬆️
+Prueba definir un usuario `Regular` con nombre y edad ⬆️
 
-Sólo añadimos una edad, pero cada variante en un tipo puede diverger mucho más. Por ejemplo, podríamos querer añadir información de ubicación a los usuarios `Regular`, para ofrecer chats regionales; basta con agregar esa información a su variante. O tal vez queremos tener usuarios anónimos también, y para eso podemos añadir una variante `Anonymous`.
+Sólo hemos añadido la edad, pero cada variante en un tipo puede diverger mucho más. Por ejemplo, podríamos querer añadir información de ubicación a los usuarios `Regular`, para ofrecer chats regionales; basta con agregar esa información a su variante. O tal vez queremos tener usuarios anónimos también, y para eso podemos añadir una variante `Anonymous`.
 
 ```elm
 type User
@@ -104,7 +104,7 @@ type User
 
 ## Mensajes
 
-En la sección de arquitectura, vimos algunos ejemplos de definir un tipo `Msg`. Esta clase de tipo es extremadamente común en Elm. En nuestro chat, tal vez necesitemos un tipo `Msg` como este:
+En la sección de arquitectura vimos algunos ejemplos donde definimos un tipo `Msg`. Usar tipos personalizados es la manera más usual y recomendada de definir los mensajes. En nuestro chat, tal vez necesitemos un tipo `Msg` como este:
 
 ```elm
 type Msg
@@ -114,11 +114,11 @@ type Msg
     | ClickedExit
 ```
 
-Tenemos cuatro variantes. Algunas variantes no llevan información asociada, otras llevan bastante. Fíjate en que `ReceivedMessage` lleva un registro asociado. Es totalmente normal. Cualquier tipo puede ser parte de esa información asociada. Esto te permite describir interacciones en tu aplicación en forma muy precisa.
+Tenemos cuatro variantes. Algunas variantes no llevan información asociada, otras llevan bastante. Fíjate en que `ReceivedMessage` lleva un registro asociado. Es totalmente normal; cualquier tipo puede ser parte de esa información asociada. Esto te permite describir interacciones en tu aplicación en forma muy precisa.
 
 ## Modelado
 
-Los tipos personalizados se vuelven muy poderosos cuando empiezas a modelar situaciones en forma precisa. Por ejemplo, si estás esperando que se carguen ciertos datos, puedes querer un modelo con un tipo personalizado así:
+Los tipos personalizados se vuelven muy poderosos cuando empiezas a modelar situaciones en forma precisa. Por ejemplo, si estás esperando que se carguen ciertos datos, puedes querer un modelo con un tipo personalizado como este:
 
 ```elm
 type Profile
@@ -131,4 +131,4 @@ Empiezas en el estado `Loading`, y luego haces la transición a `Failure` o `Suc
 
 ¡Ya aprendimos a crear tipos personalizados! En la próxima sección vamos a ver cómo usarlos.
 
-> **Nota:** **Los tipos personalizados son la funcionalidad más importante de Elm.** Tienen muchísima profundidad, especialmente cuando entres en el hábito de modelar situaciones en forma bien precisa. Traté de comunicar esta profundidad en los apéndices [“Tipos como conjuntos”](/appendix/types_as_sets.html) y [“Tipos como bits”](/appendix/types_as_bits.html). Ojalá los encuentres útiles.
+> **Nota:** **Los tipos personalizados son la funcionalidad más importante de Elm.** Tienen muchísima profundidad, especialmente cuando entres en el hábito de modelar estados en forma bien precisa. Escribí los apéndices [“Tipos como conjuntos”](/appendix/types_as_sets.html) y [“Tipos como bits”](/appendix/types_as_bits.html) para tratar de comunicar esta profundidad. Ojalá que los encuentres interesantes.

--- a/book/types/pattern_matching.md
+++ b/book/types/pattern_matching.md
@@ -32,7 +32,7 @@ toName user =
 
 La expresión `case` nos permite bifurcar el código en base a la variante que recibamos. Sea “Thomas” o “Kate”, siempre sabremos cómo mostrar su nombre.
 
-Y si intentamos pasarle argumentos inválidos, como `toName (Visitar "kate95")` o `toName Anonymous`, el compilador nos va a avisar inmediatamente. Esto significa que muchos errores simples pueden ser corregidos en segundos, en vez de aparecerle a los usuarios y terminar costando mucho más tiempo al fin y al cabo.
+Y si intentamos pasarle argumentos inválidos, como `toName (Bisitor "kate95")` o `toName Anonymous`, el compilador nos avisará inmediatamente. Esto significa que muchos errores simples pueden ser corregidos en segundos, en vez de aparecerle a los usuarios y terminar costando mucho más tiempo al fin y al cabo.
 
 ## Comodines
 

--- a/book/types/reading_types.md
+++ b/book/types/reading_types.md
@@ -1,6 +1,6 @@
 # Leyendo tipos
 
-En la sección [_Lo esencial del lenguaje_](/core_language.html) revisamos varios ejemplos interactivos para darnos una intuición general del lenguaje. Ahora vamos a volver a hacer lo mismo, pero con una nueva pregunta en mente. ¿Qué **tipo** de valor es este?
+En la sección [_Fundamentos del lenguaje_](/core_language.html) revisamos varios ejemplos interactivos para desarrollar una intuición general del lenguaje. Ahora vamos a volver a hacer lo mismo, pero con una nueva pregunta en mente: ¿Qué **tipo** de valor es este?
 
 ## Valores primitivos y listas
 
@@ -28,17 +28,16 @@ Ingresemos algunas expresiones simples y veamos qué pasa:
 {% endreplWithTypes %}
 <!-- prettier-ignore-end -->
 
-Haz clic sobre esta caja negra ⬆️ y verás un cursor parpadeando. Escribe `3.1415` y apreta ENTER. Debería aparecer `3.1415` seguido del tipo `Float`.
+Haz clic sobre esta caja negra ⬆️ y verás un cursor parpadeando. Escribe `3.1415` y apreta “enter”. Debería aparecer `3.1415` seguido del tipo `Float`.
 
-Okay, but what is going on here exactly? Each entry shows value along with what **type** of value it happens to be. You can read these examples out loud like this:
-Okay, pero ¿qué está ocurriendo aquí, exactamente? Cada fila muestra un valor junto con el **tipo** del valor al que corresponde. Puedes leer estos valores de esta forma:
+Okay, pero ¿qué es esto, exactamente? Cada fila muestra un valor junto con el **tipo** que le corresponde al valor. Puedes leer estos ejemplos de esta forma:
 
 - El valor `"hello"` es un `String`.
 - El valor `False` es un `Bool`.
 - El valor `3` es un `Int`.
 - El valor `3.1415` es un `Float`.
 
-El es capaz de reconocer el tipo de cualquier valor que ingreses. Veamos qué pasa con listas:
+Elm reconoce el tipo de cualquier valor que ingresemos. Veamos qué pasa con listas:
 
 <!-- prettier-ignore-start -->
 {% replWithTypes %}
@@ -96,11 +95,11 @@ La función `String.length` tiene el tipo `String -> Int`. Esto significa que _t
 {% endreplWithTypes %}
 <!-- prettier-ignore-end -->
 
-Tenemos una función `String -> Int` y le pasamos un argumento `String`. Esto resulta en un `Int`.
+Le pasamos un argumento `String` a una función `String -> Int`. Esto resulta en un `Int`.
 
-¿Y qué pasa cuando no le pasas un `String`? Prueba escribir `String.length [1,2,3]` o `String.length True` y ve lo que ocurre ⬆️
+¿Y qué ocurre si le pasamos algo que no es `String`? Prueba escribir `String.length [1, 2, 3]` o `String.length True` y ve lo que ocurre ⬆️
 
-Vas a darte cuenta de que una función `String -> Int` _tiene que_ recibir un argumento `String`.
+Vas a darte cuenta de que una función `String -> Int` _debe sí o sí_ recibir un argumento `String`.
 
 <!-- prettier-ignore-start -->
 > **Nota:** Las funciones que reciben múltiples argumentos se escriben con varias flechas. Por ejemplo, esta es una función que recibe dos argumentos:
@@ -115,19 +114,18 @@ Vas a darte cuenta de que una función `String -> Int` _tiene que_ recibir un ar
 ]
 {% endreplWithTypes %}
 >
-> Si le das los dos argumentos `String.repeat 3 "ha"`, el resultado será `"hahaha"`. Puedes considerar `->` como una forma rara de separar los argumentos, pero explico su real significado [aquí](/appendix/function_types.md). ¡Es bastante interesante!
+> Si le pasas dos argumentos, así: `String.repeat 3 "ha"`, el resultado será `"hahaha"`. Puedes considerar `->` como una forma rara de separar los argumentos, pero [la razón de por qué se escribe así la explico aquí](/appendix/function_types.md). ¡Es bastante interesante!
 <!-- prettier-ignore-end -->
 
 ## Anotaciones de tipo
 
-Hasta ahora hemos permitido que Elm determine los tipos, pero también podemos escribir una **anotación de tipo** en la lina justo arriba de una definición. Es decir que en nuestro código podemos escribir cosas como estas:
+Hasta ahora hemos permitido que Elm infiera el tipado, pero también podemos **anotar tipos** en la línea justo arriba de una definición. Es decir, podemos escribir algo así:
 
+<!-- prettier-ignore-start -->
 ```elm
 half : Float -> Float
 half n =
     n / 2
-
-
 
 -- half 256 == 128
 -- half "3" -- error!
@@ -136,8 +134,6 @@ half n =
 hypotenuse : Float -> Float -> Float
 hypotenuse a b =
     sqrt (a ^ 2 + b ^ 2)
-
-
 
 -- hypotenuse 3 4  == 5
 -- hypotenuse 5 12 == 13
@@ -151,18 +147,17 @@ checkPower powerLevel =
     else
         "Meh"
 
-
-
 -- checkPower 9001 == "It's over 9000!!!"
 -- checkPower True -- error!
 ```
+<!-- prettier-ignore-end -->
 
-No es necesario añadir anotaciones de tipo, pero definitivamente te lo recomiendo. Estos son algunos beneficios:
+No es necesario anotar tipos, pero definitivamente lo recomiendo. Estos son algunos beneficios:
 
-1. **Calidad de los mensajes de error** — Cuando escribes una anotación de tipo, le estás contando al compilador _tu intención_. Tu implementación puede que tenga errores, y el compilador puede comparar eso con tu intención. “Dijiste que el argumento `powerLevel` era `Int`, pero está siendo usado como `String`”.
-2. **Documentación** — Cuando vuelvas a enfrentarte a tu código más tarde (o cuando un colega lo haga por primera vez) va a ser muy útil ver exactamente lo que recibe y devuelve una función sin tener que leer la implementación en detalle.
+1. **Calidad de los mensajes de error** — Cuando anotamos un tipo, le estamos diciendo al compilador nuestra _intención_. La implementación puede que tenga errores, y después de comparar el código con nuestra anotación, el compilador nos dará un mensaje del tipo: “Dijiste que el argumento `powerLevel` era `Int`, pero está siendo usado como `String`”.
+2. **Documentación** — Cuando pase un tiempo sin que trabajemos sobre el mismo código, o cuando un colega lo haga por primera vez, va a ser muy útil ver exactamente lo que recibe y devuelve una función sin tener que leer la implementación en detalle.
 
-Pero la gente puede cometer errores al escribir anotaciones de tipo, así que ¿qué pasa si la anotación no coincide con la implementación? El compilador determina todos los tipos por su cuenta y confirma que tu anotación coincide con la respuesta real. En otras palabras, el compilador siempre verificará que todas las anotaciones que escribas estén correctas. Así tendrás mejores mensajes de error _y además_ tu documentación se mantendrá siempre al día.
+Pero la gente igual puede cometer errores al anotar tipos, así que ¿qué pasa si la anotación no coincide con la implementación? Pues, el compilador determina todos los tipos por su cuenta y confirma que tu anotación coincide con la respuesta real. En otras palabras, el compilador siempre verificará que todas las anotaciones que escribas estén correctas. Así tendrás mejores mensajes de error _y además_ tu documentación se mantendrá siempre al día.
 
 ## Variables de tipo
 
@@ -180,7 +175,7 @@ A medida que revises más código Elm, te irás dando cuenta de que existen anot
 {% endreplWithTypes %}
 <!-- prettier-ignore-end -->
 
-Fíjate en esa `a` minúscula en el tipo. Esto se llama una **variable de tipo**. Puede cambiar según cómo se use [`List.length`][length]:
+Fíjate en esa `a` minúscula en el tipo. Esto se llama una **variable de tipo**. Su significado puede cambiar según cómo se use [`List.length`][length]:
 
 <!-- prettier-ignore-start -->
 {% replWithTypes %}
@@ -204,7 +199,7 @@ Fíjate en esa `a` minúscula en el tipo. Esto se llama una **variable de tipo**
 {% endreplWithTypes %}
 <!-- prettier-ignore-end -->
 
-Sólo necesitamos el largo de la lista, así que no nos importa lo que contenga la lista. Así que el la variable de tipo `a` nos dice que puede calzar con cualquier tipo. Veamos otro ejemplo común:
+Como sólo queremos el largo de la lista, no nos importa qué lleva dentro. La variable de tipo `a` significa que ahí puede ir cualquier tipo. Veamos otro ejemplo común:
 
 <!-- prettier-ignore-start -->
 {% replWithTypes %}
@@ -228,17 +223,16 @@ Sólo necesitamos el largo de la lista, así que no nos importa lo que contenga 
 {% endreplWithTypes %}
 <!-- prettier-ignore-end -->
 
-Otra vez, la variable de tipo `a` puede cambiar según cómo [`List.reverse`][reverse] sea usada. Pero en este caso, tenemos una `a` en el argumento y en el resultado. Esto significa que si le das una `List Int` deberás recibir una `List Int` también. Una vez que decidimos lo que es esa `a`, será lo mismo después también.
+Otra vez, la variable de tipo `a` puede cambiar según cómo usemos [`List.reverse`][reverse]. Pero en este caso, tenemos una `a` tanto en el argumento como en el tipo de retorno. Esto significa que si le pasas una `List Int`, deberás recibir una `List Int` también. Una vez que se decide lo que es esa `a`, seguirá siendo lo mismo después.
 
-> **Nota:** Las variables de tipo deben empezar con una letra minúscula, pero pueden ser palabras completas. Podemos escribir el tipo de `List.length` como `List value -> Int` y podríamos escribir el tipo de `List.reverse` como `List element -> List element`. Funciona siempre y cuando comiencen con una letra minúscula. Las variables de tipo `a` y `b` son usadas por convención en muchos lugares, pero algunas anotaciones de tipo quedan mejor con nombres más específicos.
+> **Nota:** Las variables de tipo deben empezar con una letra minúscula, pero pueden ser palabras completas. Podemos escribir el tipo de `List.length` como `List value -> Int` y podríamos escribir el tipo de `List.reverse` como `List element -> List element`. Funciona siempre y cuando comiencen con una letra minúscula. Las variables de tipo `a` y `b` son usadas por convención en muchos lugares, pero algunas anotaciones quedan mejor con nombres más específicos.
 
 [length]: https://package.elm-lang.org/packages/elm/core/latest/List#length
 [reverse]: https://package.elm-lang.org/packages/elm/core/latest/List#reverse
 
 ## Variables limitadas de tipo
 
-There is a special variant of type variables in Elm called **constrained** type variables. The most common example is the `number` type. The [`negate`](https://package.elm-lang.org/packages/elm/core/latest/Basics#negate) function uses it:
-Hay una variante especial de las variables de tipo en Elm que se llama variables **limitadas** de tipo. El ejemplo más común es el del tipo `number`. La función [`negate`](https://package.elm-lang.org/packages/elm/core/latest/Basics#negate) la usa:
+Hay una variedad especial de variable de tipo en Elm que llamamos variables **limitadas** de tipo. El ejemplo más común es el tipo `number`. La función [`negate`](https://package.elm-lang.org/packages/elm/core/latest/Basics#negate) la usa:
 
 <!-- prettier-ignore-start -->
 {% replWithTypes %}
@@ -254,15 +248,15 @@ Hay una variante especial de las variables de tipo en Elm que se llama variables
 
 Prueba escribir expresiones como `negate 3.1415` o `negate (round 3.1415)` o `negate "hi"` ⬆️
 
-Normalmente, las variables de tipo pueden rellenarse con cualquier cosa, pero `number` sólo puede rellenarse con valores `Int` y `Float`. _Limita_ las posibilidades.
+Normalmente, las variables de tipo pueden rellenarse con cualquier cosa, pero `number` sólo puede rellenarse con valores `Int` y `Float`. O sea, _limita_ las posibilidades.
 
-La lista completa de variables limitadas de tipo es:
+Esta es la lista completa de variables limitadas de tipo:
 
 - `number` permite `Int` y `Float`
 - `appendable` permite `String` y `List a`
-- `comparable` permite `Int`, `Float`, `Char`, `String`, y listas o tuplas de valores `comparable`
+- `comparable` permite `Int`, `Float`, `Char`, `String` y listas o tuplas de valores `comparable`
 - `compappend` permite `String` y `List comparable`
 
 Estas variables limitadas de tipo existen para que ciertos operadores como `(+)` y `(<)` puedan ser un poco más flexibles.
 
-Ya cubrimos bastante bien los tipos de valores y funciones, pero ¿cómo se ve esto cuando empezamos a necesitar estructuras de datos más complejas?
+Ya cubrimos bastante bien los tipos de valores y funciones, pero ¿cómo se ve esto cuando empezamos a necesitar estructuras más complejas de datos?

--- a/book/types/type_aliases.md
+++ b/book/types/type_aliases.md
@@ -1,6 +1,6 @@
 # Alias de tipo
 
-Las anotaciones de tipo pueden quedar un poco extensas. Esto se vuelve particularmente problemático si tienes registros con muchos campos. Esa es la razón por la que existen los alias de tipo. Un **alias de tipo** es un nombre corto para un tipo. Por ejemplo, puedes creas un alias `User` de esta forma:
+Las anotaciones de tipo pueden quedar un poco grandes. Esto se vuelve particularmente problemático si tienes registros con muchos campos. Esa es la razón por la que existen los alias de tipo. Un **alias de tipo** es un nombre corto para un tipo. Por ejemplo, puedes creas un alias `User` de esta forma:
 
 ```elm
 type alias User =
@@ -33,7 +33,7 @@ Estas dos definiciones son equivalentes, pero la que lleva el alias de tipo es m
 
 ## Modelos
 
-Es súper común usar alias de tipo al diseñar el modelo. Cuando aprendimos sobre la Arquitectura Elm, usamos este modelo:
+Es súper común usar un alias de tipo al diseñar el modelo. Cuando aprendimos sobre la Arquitectura Elm, usamos este modelo:
 
 ```
 type alias Model =
@@ -43,7 +43,7 @@ type alias Model =
   }
 ```
 
-El principal beneficio de usar un alias de tipo es para cuando escribamos las anotaciones para las funciones `update` y `view`. Es mucho más sensato escribir `Msg -> Model -> Model` que la versión larga. Además tiene el beneficio de que podemos añadir campos a nuestro modelo sin necesitar cambiar anotaciones de tipo.
+El principal beneficio de escribir el modelo usando un alias de tipo es para la anotación de tipo de las funciones `update` y `view`. Es mucho más sensato escribir `Msg -> Model -> Model` que la versión larga. Además tiene el beneficio de que podemos añadir campos a nuestro modelo sin necesitar cambiar anotaciones de funciones.
 
 ## Constructores de registro
 
@@ -77,6 +77,6 @@ Cuando creas un alias de tipo para un registro específicamente, también se gen
 
 Prueba crear un usuario o un alias de tipo nuevo ⬆️
 
-Fíjate en que el orden de los argumentos que recibe el constructor es el mismo que el orden de los campos en el alias de tipo.
+Como puedes apreciar, un constructor de registro no es ni más ni menos que una función para generar un valor de ese tipo en forma abreviada. Esta función recibe la misma cantidad de argumentos y en el mismo orden que los campos definidos en el alias de tipo.
 
-Y repito, **esto sólo vale para registros**. Cuando crees alias de tipo para otros tipos no se generará un constructor.
+Y repito, **esto sólo vale para registros**. Si creamos un alias para otros tipos, no se generará un constructor.

--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 [private]
-default:
-    just --list
+@default:
+    just --list --unsorted
 
 # Levanta un servidor con una previsualización del libro.
 preview: install build-repl


### PR DESCRIPTION
Estoy pasando una segunda mano al texto de todas las páginas. En este PR llego hasta la sección Tipos. Creo que ahora sí está quedando mucho más natural y consistente, ya que la primera pasada fue bien acelerada.

También añadí un ajuste mejor en la tarea por defecto del `justfile`.