### PR TITLE
Ajustes menores

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Las tareas ejecutables están gestionadas con el comando `just`. Corriendo ese c
 
 ## Traduciendo
 
-El objetivo central de esta traducción es **contribuir a diseminar el uso de Elm y sus ideas en la comunidad hispanohablante de programadores**, particularmente de Hispanoamérica. Por supuesto, más allá de este grupo principal, todos son bienvenidos a hacer uso de esta traducción.
+El objetivo central de esta traducción es **contribuir a diseminar el uso de Elm y sus ideas en la comunidad hispanohablante de programadores**, particularmente de Latinoamérica. Por supuesto, más allá de este grupo principal, todos son bienvenidos a hacer uso de esta traducción.
 
 Los siguientes son otros ideales y directrices para este proyecto.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [_Introducción a Elm_](https://agj.github.io/elm-guide-es) (también conocido como “la guía”) es un libro sobre el lenguaje de programación funcional [Elm](https://elm-lang.org/), que compila a JavaScript. Su creador lo describe como “un lenguaje para deleitarse construyendo aplicaciones web confiables”.
 
-El libro es de autoría del creador del lenguaje mismo, Evan Czaplicki. Esta es la traducción al español hispanoamericano, hecha 100% por humanos. [La versión original en inglés está disponible aquí.](https://guide.elm-lang.org)
+El libro es de autoría del creador del lenguaje mismo, Evan Czaplicki. Esta es la traducción al español latinoamericano, hecha 100% por humanos. [La versión original en inglés está disponible aquí.](https://guide.elm-lang.org)
 
 ## ¿Descubriste un error? ¿Algo no se entiende?
 

--- a/book/README.md
+++ b/book/README.md
@@ -10,21 +10,23 @@ Esta guía va a:
 
 Al terminar, espero que no sólo seas capaz de crear excelentes aplicaciones web con Elm, sino que también entiendas las ideas y patrones centrales que forman la experiencia de usar Elm.
 
-Aunque no tengas completa seguridad de que Elm es para ti, te garantizo que si le das una oportunidad e intentas construir un proyecto usándolo, vas a poder escribir mejor JavaScript que antes. Es muy fácil aplicar las mismas ideas en otros contextos.
+Aunque no tengas completa seguridad de que Elm es para ti, te garantizo que si le das una oportunidad e intentas construir un proyecto usándolo, vas a poder escribir mejor JavaScript que antes. Son ideas que se pueden aplicar en cualquier lado.
 
 ## Sobre la traducción
 
 Antes de empezar, un poquito de contexto. Estás leyendo la traducción no oficial al español latinoamericano del libro de Evan Czaplicki, autor de Elm. [Aquí está el libro original en inglés.](https://guide.elm-lang.org/)
 
-**Nota:** ¡Esta traducción aún está en desarrollo! Hay cosas que aún no están traducidas, posibles errores, y funcionalidades incompletas. Aún así, es una _traducción humana_ a la que le hemos puesto mucho cariño, y esperamos que te sea útil. ❤️
+**Nota:** El texto principal está completamente traducido, pero hay algunas cosas que están pendientes, por ejemplo los comentarios en cierto código de ejemplo, o links a contenido en inglés. También vas a encontrar funcionalidades incompletas, y seguramente uno que otro error. Aún así, es una _traducción humana_ a la que le hemos puesto mucho cariño, y esperamos que te sea útil. 🩵
 
 ¿Quieres escribirnos un **comentario**, mandar una **corrección**, o **aportar** con la traducción o sus aspectos técnicos? [El repositorio en Github](https://github.com/agj/elm-guide-es) es el lugar indicado.
 
 **¿Está al día la traducción?** Puedes [revisar aquí si hay nuevos cambios en el libro original](https://github.com/evancz/guide.elm-lang.org/compare/a6030f9968724629c374b936c552d2b8d2b30f31...master).
 
+Ahora sí, entremos en materia.
+
 ## Un ejemplo sencillo
 
-Ahora sí, entremos en materia. Este es un pequeño programa que te permite incrementar y decrementar un número:
+Este es un pequeño programa que te permite incrementar y decrementar un número:
 
 ```elm
 import Browser

--- a/book/README.md
+++ b/book/README.md
@@ -14,7 +14,7 @@ Aunque no tengas completa seguridad de que Elm es para ti, te garantizo que si l
 
 ## Sobre la traducción
 
-Antes de empezar, un poquito de contexto. Estás leyendo la traducción no oficial al español hispanoamericano del libro de Evan Czaplicki, autor de Elm. [Aquí está el libro original en inglés.](https://guide.elm-lang.org/)
+Antes de empezar, un poquito de contexto. Estás leyendo la traducción no oficial al español latinoamericano del libro de Evan Czaplicki, autor de Elm. [Aquí está el libro original en inglés.](https://guide.elm-lang.org/)
 
 **Nota:** ¡Esta traducción aún está en desarrollo! Hay cosas que aún no están traducidas, posibles errores, y funcionalidades incompletas. Aún así, es una _traducción humana_ a la que le hemos puesto mucho cariño, y esperamos que te sea útil. ❤️
 


### PR DESCRIPTION
- Cambié el término “hispanoamérica” por el más habitual “latinoamérica”.
- Ajusté un poco la explicación sobre la traducción que está en la primera página, dejándolo un poquito más concreto.