### PR TITLE
Corrige no se leen diagramas al usar tema oscuro

### DIFF
--- a/book/styles/website.css
+++ b/book/styles/website.css
@@ -105,6 +105,10 @@
   color: inherit;
 }
 
+.book.color-theme-2 .book-body img {
+  background-color: currentColor;
+}
+
 /* CORRECT SEARCH BAR FORMAT */
 
 #book-search-input {


### PR DESCRIPTION
Pone un fondo claro a los diagramas (el mismo color del texto) sólo cuando se usa el tema oscuro. Como son SVGs transparentes, el texto negro no se lee de otra forma.

<img width="1598" height="1184" src="https://github.com/user-attachments/assets/716ddfab-8945-4e98-b845-aa4645a586f3" />
